### PR TITLE
Fix MogIt integration LUA error

### DIFF
--- a/Plugins/MogIt.lua
+++ b/Plugins/MogIt.lua
@@ -115,16 +115,18 @@ function MogIt.GetMogitOutfits()
 		--print(itemLink)
 			if itemLink then
 				local appearanceID, sourceID = C_TransmogCollection.GetItemInfo(itemLink)
-				local sourceInfo = C_TransmogCollection.GetSourceInfo(sourceID)
-				local appearanceID = sourceInfo.visualID
-				local itemID = sourceInfo.itemID
-				local itemMod = sourceInfo.itemModID
-				----print(invSlot)
-				data.itemData[slotID] = {"'"..itemID..":"..itemMod.."'", sourceID, appearanceID}
-				if not data.icon then
-					--local categoryID, visualID, canEnchant, icon, isCollected, itemLink, transmogLink, unknown1 = C_TransmogCollection.GetAppearanceSourceInfo(itemLink)
-					local _, _, _, _, icon, _, _ = GetItemInfoInstant(itemLink) 
-					data.icon = icon
+				local sourceInfoSuccess, sourceInfo = pcall(C_TransmogCollection.GetSourceInfo, sourceID)
+				if (sourceInfoSuccess) then
+					local appearanceID = sourceInfo.visualID
+					local itemID = sourceInfo.itemID
+					local itemMod = sourceInfo.itemModID
+					--print(invSlot)
+					data.itemData[slotID] = {"'"..itemID..":"..itemMod.."'", sourceID, appearanceID}
+					if not data.icon then
+						--local categoryID, visualID, canEnchant, icon, isCollected, itemLink, transmogLink, unknown1 = C_TransmogCollection.GetAppearanceSourceInfo(itemLink)
+						local _, _, _, _, icon, _, _ = GetItemInfoInstant(itemLink) 
+						data.icon = icon
+					end
 				end
 			end
 		end


### PR DESCRIPTION
I was previously unable to use MogIt integration - in fact, it would render the transmog window's saved sets tab unusable if I had MogIt enabled also.

This is the LUA error I would get: `"Usage: local sourceInfo = C_TransmogCollection.GetSourceInfo(sourceID)"`

Then, all of the saved sets would render my character naked, and I was unable to select any of them.

I found that while `MogIt.GetMogitOutfits` was looping, it would sometimes find an item it was unable to get the source info of. This caused the entire thing to crash out.

Instead, I put the function in a protected call. This tries to get the source info, and if it can't, it just skips instead of erroring/canceling.

I am NOT a LUA developer - this was cobbled together with a lot of Googling around. I may have gone about it in the wrong way, but it seems to have made everything work perfectly again. Please let me know if there is a better way to do this. Thank you!