### PR TITLE
Fix "substitue" typos, replace with "substitute"

### DIFF
--- a/Locale/deDE.lua
+++ b/Locale/deDE.lua
@@ -309,7 +309,7 @@ L["Added missing appearances of: \124cffff7fff\124H%s:%s\124h[%s]\124h\124r"] = 
 L["Added appearance in Collection List"] = "Vorlage in Sammelliste hinzugefügt"
 
 L["Set Substitution"] = "Ersatz festlegen"
-L["Substitue Item"] = "Gegenstand ersetzen"
+L["Substitute Item"] = "Gegenstand ersetzen"
 
 L["Item No Longer Available"] = "Gegenstand nicht länger verfügbar"
 

--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -327,7 +327,7 @@ L["Added missing appearances of: \124cffff7fff\124H%s:%s\124h[%s]\124h\124r"] = 
 L["Added appearance in Collection List"] = true
 
 L["Set Substitution"] = true
-L["Substitue Item"] = true
+L["Substitute Item"] = true
 
 L["Item No Longer Available"] = true
 

--- a/Locale/zhTW.lua
+++ b/Locale/zhTW.lua
@@ -303,7 +303,7 @@ L["Added missing appearances of: \124cffff7fff\124H%s:%s\124h[%s]\124h\124r"] = 
 L["Added appearance in Collection List"] = "在收藏清單中新增外觀"
 
 L["Set Substitution"] = "設定替代品"
-L["Substitue Item"] = "替代品"
+L["Substitute Item"] = "替代品"
 
 L["Item No Longer Available"] = "物品不再可用"
 

--- a/Modules/Wardrobe.lua
+++ b/Modules/Wardrobe.lua
@@ -6477,7 +6477,7 @@ local BW_ItemSubDropDownMenu_Table = {
 }
 local BW_ExtraItemSubDropDownMenu_Table = {
 	{
-		text = L["Substitue Item"],
+		text = L["Substitute Item"],
 		func = function(self)    		
 			BetterWardrobeOutfitFrameMixin:ShowPopup("BETTER_WARDROBE_SUBITEM_POPUP")
 		end,


### PR DESCRIPTION
* Fixes typos where "Substitute" was spelled as `Substitue`