### PR TITLE
Fix some misc issues

### DIFF
--- a/Data/DataBase.lua
+++ b/Data/DataBase.lua
@@ -1299,7 +1299,7 @@ end
 		return visualID ,sourceID
 	end
 
-	function addon.GetSetsources(setID)
+	function addon.GetSetSources(setID)
 		--return C_TransmogSets.GetSetPrimaryAppearances(setID)
 		return addon.C_TransmogSets.GetSetSources(setID)
 	end

--- a/Modules/BlizzardAPI.lua
+++ b/Modules/BlizzardAPI.lua
@@ -360,7 +360,7 @@ local function CheckMissingLocation(setInfo)
 			end
 
 		else
-			local setSources = addon.GetSetsources(setInfo.setID)
+			local setSources = addon.GetSetSources(setInfo.setID)
 			for sourceID, isCollected in pairs(setSources) do
 				local sourceInfo = C_TransmogCollection.GetSourceInfo(sourceID)
 				if missingSelection[sourceInfo.invType] and not isCollected then

--- a/Modules/CollectionList.lua
+++ b/Modules/CollectionList.lua
@@ -139,7 +139,7 @@ function CollectionList:UpdateList(type, typeID, add, sourceID)
 			setName = C_TransmogSets.GetSetInfo(typeID).name
 		else
 			setInfo = addon.GetSetInfo(typeID)
-			sources = addon.GetSetsources(typeID)
+			sources = addon.GetSetSources(typeID)
 			setName = "name"
 			itemModID = setInfo.mod or 0
 		end
@@ -360,7 +360,7 @@ function CollectionList:OptionButton_OnClick(button)
 
 	end
 	
-	MenuUtil.CreateContextMenu(parent, GeneratorFunction);
+	MenuUtil.CreateContextMenu(button, GeneratorFunction);
 
 end
 

--- a/Modules/DressingRoom.lua
+++ b/Modules/DressingRoom.lua
@@ -578,7 +578,7 @@ local function DressupSettingsButton_OnClick(self)
 		rootDescription:CreateCheckbox(L["Hide Shirt"], function() return Profile.DR_HideShirt end, function() Profile.DR_HideShirt = not Profile.DR_HideShirt end);
 	end
 	
-	MenuUtil.CreateContextMenu(parent, GeneratorFunction);
+	MenuUtil.CreateContextMenu(self, GeneratorFunction);
 end
 
 local function BW_DressingRoomImportButton_OnClick(self)
@@ -632,7 +632,7 @@ local function BW_DressingRoomImportButton_OnClick(self)
 
 		end
 	
-	MenuUtil.CreateContextMenu(parent, GeneratorFunction);
+	MenuUtil.CreateContextMenu(self, GeneratorFunction);
 end
 
 

--- a/Modules/Tooltips.lua
+++ b/Modules/Tooltips.lua
@@ -506,7 +506,7 @@ function preview:ShowPreview(itemLink, parent)
 					addDoubleLine (GameTooltip," ",L["-%s %s(%d/%d)"]:format(data.name or "", color, collected, total))
 
 					if addon.Profile.ShowDetailedListTooltips then
-						local sources = addon.GetSetsources(data.setID)
+						local sources = addon.GetSetSources(data.setID)
 						for sourceID, collected in pairs(sources) do
 							local sourceInfo = C_TransmogCollection.GetSourceInfo(sourceID)
 							if collected and not addon.Profile.ShowMissingDetailedListTooltips then


### PR DESCRIPTION
Love the addon - just throwing my hat in the ring to fix up a few random bugs. `GetSetSources` was used in a few different places - sometimes as `GetSetSources` and sometimes as `GetSetsources` (leading to some nil value errors when using the wrong casing). I've renamed the function to `GetSetSources` and fixed up all the usages of it. You also had a few functions where I think parent/self was incorrectly set, probably from some refactoring. 