### PR TITLE
Fix a few errors from mixing up custom set indices and Blizzard set IDs

### DIFF
--- a/Modules/SavedOutfits.lua
+++ b/Modules/SavedOutfits.lua
@@ -906,7 +906,7 @@ end
 -- customSetID - Set if editing an existing custom set, nil if new custom set flow.
 -- itemTransmogInfoList - Transmog info list to populate any custom set with (overriding existing or adding a new custom set).
 StaticPopupDialogs["BW_TRANSMOG_CUSTOM_SET_NAME"] = {
-	text = TRANSMOG_CUSTOM_SET_NAME.."!",
+	text = TRANSMOG_CUSTOM_SET_NAME,
 	button1 = SAVE,
 	button2 = CANCEL,
 	OnAccept = function(dialog, data)

--- a/Modules/SavedOutfits.lua
+++ b/Modules/SavedOutfits.lua
@@ -928,7 +928,7 @@ StaticPopupDialogs["BW_TRANSMOG_CUSTOM_SET_NAME"] = {
 
 		if data then
 			WardrobeCustomSetManager:SetItemTransmogInfoList(data.itemTransmogInfoList);
-			dialog:GetEditBox():SetText(data.name.name);
+			dialog:GetEditBox():SetText(data.name);
 		end
 	end,
 	OnHide = function(dialog, data)

--- a/Modules/Transmog.lua
+++ b/Modules/Transmog.lua
@@ -2572,15 +2572,22 @@ function TransmogWardrobeCustomSetsMixin:RefreshNewCustomSetButton()
 end
 
 function TransmogWardrobeCustomSetsMixin:RefreshCollectionEntries()
+	local getEntryName = function(element)
+		if element.setType == "Blizzard" then
+			local customSetName, _customSetIcon = C_TransmogCollection.GetCustomSetInfo(element.customSetID);
+			return customSetName;
+		else
+			local outfit = addon.OutfitDB.char.outfits[element.customSetID];
+			return outfit and outfit.name;
+		end
+	end
+
 	local compareEntries = function(element1, element2)
 		if element1.isCollected ~= element2.isCollected then
 			return element1.isCollected;
 		end
 
-
-		local customSetName1, _customSetIcon1 = C_TransmogCollection.GetCustomSetInfo(element1.customSetID);
-		local customSetName2, _customSetIcon2 = C_TransmogCollection.GetCustomSetInfo(element2.customSetID);
-		return customSetName1 < customSetName2;
+		return (getEntryName(element1) or "") < (getEntryName(element2) or "");
 	end
 
 	local collectionElements = {};

--- a/Modules/TransmogTemplates.lua
+++ b/Modules/TransmogTemplates.lua
@@ -1789,7 +1789,7 @@ function TransmogCustomSetModelMixin:OnMouseUp(button)
 				local data = { name = name, customSetID = self.elementData.customSetID, itemTransmogInfoList = itemTransmogInfoList };
 				StaticPopup_Show("TRANSMOG_CUSTOM_SET_NAME", nil, nil, data);
 			else
-				local name = addon.OutfitDB.char.outfits[self.elementData.customSetID];
+				local name = addon.OutfitDB.char.outfits[self.elementData.customSetID].name or "";
 				local data = { name = name, customSetID = self.elementData.customSetID, itemTransmogInfoList = itemTransmogInfoList };
 				StaticPopup_Show("BW_TRANSMOG_CUSTOM_SET_NAME", nil, nil, data);
 			end

--- a/Modules/TransmogTemplates.lua
+++ b/Modules/TransmogTemplates.lua
@@ -1907,8 +1907,14 @@ function TransmogCustomSetModelMixin:RefreshTooltip()
 
 	GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
 
-	local name, _icon = C_TransmogCollection.GetCustomSetInfo(self.elementData.customSetID);
-	GameTooltip:SetText(name);
+	local name;
+	if self.elementData.setType == "Blizzard" then
+		name = C_TransmogCollection.GetCustomSetInfo(self.elementData.customSetID);
+	else
+		local outfit = addon.OutfitDB.char.outfits[self.elementData.customSetID];
+		name = outfit and outfit.name;
+	end
+	GameTooltip:SetText(name or UNKNOWN);
 
 	if self.elementData.isCollected then
 		GameTooltip_AddHighlightLine(GameTooltip, TRANSMOG_CUSTOM_SET_COMPLETE);


### PR DESCRIPTION
# Set ID Handling Fixes

This fixes some errors caused by functions querying BW custom set indices as though they were Blizzard set IDs. Functions like `TransmogCustomSetModelMixin:UpdateSet()` already handled it correctly, but `TransmogWardrobeCustomSetsMixin:RefreshCollectionEntries()` and `TransmogCustomSetModelMixin:RefreshTooltip()` didn't, and were misbehaving weirdly because of it.

Resolves SLOKnightfall/BetterWardrobe#572.

## Drive-by Fixes

While I was poking around, I also prettied up a spot where some logic in the rename button was doing this same style of thing to grab a set name, but forgot to add `.name` at the end of the BW custom set branch, so it was accidentally passing around the name as as table to some popup code, which had to work around it by accessing `data.name.name` later on instead of just `data.name`. And finally, I cut out a "!" from that rename button's text, because it already ended with a ":", so it was showing up like `Enter Custom Set Name:!` in-game.